### PR TITLE
Fix ActiveRecord::ConnectionAdapters::Column#initialize method call

### DIFF
--- a/lib/odbc_adapter/column.rb
+++ b/lib/odbc_adapter/column.rb
@@ -5,8 +5,8 @@ module ODBCAdapter
     # Add the native_type accessor to allow the native DBMS to report back what
     # it uses to represent the column internally.
     # rubocop:disable Metrics/ParameterLists
-    def initialize(name, default, sql_type_metadata = nil, null = true, table_name = nil, native_type = nil, default_function = nil, collation = nil)
-      super(name, default, sql_type_metadata, null, table_name, default_function, collation)
+    def initialize(name, default, sql_type_metadata = nil, null = true, _table_name = nil, native_type = nil, default_function = nil, collation = nil)
+      super(name, default, sql_type_metadata, null, default_function, collation: collation)
       @native_type = native_type
     end
   end


### PR DESCRIPTION
Fixes a no-longer-valid call to a super method in the adapter